### PR TITLE
Switch to bare docstrings.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 StatsBase
 Cairo
-Docile
 Lexicon

--- a/src/EcologicalNetwork.jl
+++ b/src/EcologicalNetwork.jl
@@ -4,19 +4,7 @@ module EcologicalNetwork
 using StatsBase
 using Cairo
 
-# Documentation
-using Docile
-#= XXX
-This fugly piece of code checks if Base has a @doc macro (which means we are
-working on 0.4), and if not, defaults back to the one provided by Docile. In a
-perfect world, this will be a very short-lived block.
-=#
-try
-  import Base.@doc
-catch
-  import Docile.@doc
-end
-using Lexicon
+VERSION < v"0.4-dev" && import Lexicon
 
 export nestedness, nestedness_axis,
 
@@ -59,9 +47,6 @@ export nestedness, nestedness_axis,
 
   # Motifs
   motif_p, motif_v, count_motifs, motif, motif_var
-
-@docstrings
-@document
 
 include(joinpath(".", "centrality.jl"))
 include(joinpath(".", "connectance.jl"))

--- a/src/betadiversity.jl
+++ b/src/betadiversity.jl
@@ -1,4 +1,4 @@
-@doc """ Partition of network similarity
+""" Partition of network similarity
 
 The sets are, respectively
 
@@ -9,7 +9,7 @@ The sets are, respectively
 Note that *all* values are `Float64`, since when dealing with probabilistic
 events, the expected cardinality of each set is not integers.
 
-""" ->
+"""
 type BetaSet
   a::Float64
   b::Float64
@@ -22,7 +22,7 @@ function sum(S::BetaSet)
   return S.a + S.b + S.c
 end
 
-@doc """ Measure the expected network similarity
+""" Measure the expected network similarity
 
 Note that this is only meaningful to apply this function when the two matrices
 have the same species at the same position! If this is note the case, a
@@ -37,7 +37,7 @@ actually measure the beta-diversity. This package uses the approach of Koleff et
 for presence–absence data. Journal of Animal Ecology, 72: 367–382. doi:
 10.1046/j.1365-2656.2003.00710.x
 
-""" ->
+"""
 function betadiversity(A::Array{Float64,2}, B::Array{Float64,2})
   if size(A) != size(B)
     throw(BoundsError())
@@ -53,47 +53,47 @@ TODO
 Give the reference in the docstring of each function
 =#
 
-@doc """ Whittaker measure of beta-diversity """ ->
+""" Whittaker measure of beta-diversity """
 function whittaker(S::BetaSet)
   return sum(S)/((S.a + sum(S))/2.0) - 1.0
 end
 
-@doc """ Sorensen measure of beta-diversity """ ->
+""" Sorensen measure of beta-diversity """
 function sorensen(S::BetaSet)
   return (2.0*S.a)/(S.a + sum(S))
 end
 
-@doc """ Jaccard measure of beta-diversity """ ->
+""" Jaccard measure of beta-diversity """
 function jaccard(S::BetaSet)
   return S.a/sum(S)
 end
 
-@doc """ Gaston measure of beta-diversity """ ->
+""" Gaston measure of beta-diversity """
 function gaston(S::BetaSet)
   return (S.b+S.c)/sum(S)
 end
 
-@doc """ Williams measure of beta-diversity """ ->
+""" Williams measure of beta-diversity """
 function williams(S::BetaSet)
   return minimum(vec([S.b S.c]))/sum(S)
 end
 
-@doc """ Lande measure of beta-diversity """ ->
+""" Lande measure of beta-diversity """
 function lande(S::BetaSet)
   return (S.b + S.c)/2.0
 end
 
-@doc """ Ruggiero measure of beta-diversity """ ->
+""" Ruggiero measure of beta-diversity """
 function ruggiero(S::BetaSet)
   return (S.a)/(S.a + S.c)
 end
 
-@doc """ Harte-Kinzig measure of beta-diversity """ ->
+""" Harte-Kinzig measure of beta-diversity """
 function hartekinzig(S::BetaSet)
   return 1.0 - (2.0 * S.a)/(S.a + sum(S))
 end
 
-@doc """ Harrison measure of beta-diversity """ ->
+""" Harrison measure of beta-diversity """
 function harrison(S::BetaSet)
   return minimum(vec([S.b S.c]))/(minimum(vec([S.b S.c])) + S.a)
 end

--- a/src/centrality.jl
+++ b/src/centrality.jl
@@ -1,13 +1,13 @@
 #=
 Katz's centrality
 =#
-@doc """ Measures Katz's centrality for each node in a unipartite network.
+""" Measures Katz's centrality for each node in a unipartite network.
 
 **Keyword arguments**
 
 - `a` (def. 0.1), the weight of each subsequent connection
 - `k` (def. 5), the maximal path length considered
-""" ->
+"""
 function centrality_katz(A::Array{Float64,2}; a::Float64=0.1, k::Int64=5)
 	@assert size(A)[1] == size(A)[2]
 	@assert a <= 1.0

--- a/src/connectance.jl
+++ b/src/connectance.jl
@@ -1,26 +1,26 @@
-@doc """ Expected number of links for a probabilistic matrix
-""" ->
+""" Expected number of links for a probabilistic matrix
+"""
 function links(A::Array{Float64,2})
    return sum(A)
 end
 
-@doc """ Expected variance of the number of links for a probabilistic matrix
-""" ->
+""" Expected variance of the number of links for a probabilistic matrix
+"""
 function links_var(A::Array{Float64,2})
    return sum(A.*(1.-A))
 end
 
-@doc """ Expected connectance for a probabilistic matrix, measured as the number
+""" Expected connectance for a probabilistic matrix, measured as the number
 of expected links, divided by the size of the matrix.
-""" ->
+"""
 function connectance(A::Array{Float64,2})
    return links(A) / prod(size(A))
 end
 
-@doc """ Expected variance of the connectance for a probabilistic matrix,
+""" Expected variance of the connectance for a probabilistic matrix,
 measured as the variance of the number of links divided by the squared size of
 the matrix.
-""" ->
+"""
 function connectance_var(A::Array{Float64,2})
    return links_var(A) / (prod(size(A))^2)
 end

--- a/src/degree.jl
+++ b/src/degree.jl
@@ -1,17 +1,17 @@
-@doc """ Expected number of outgoing degrees
-""" ->
+""" Expected number of outgoing degrees
+"""
 function degree_out(A::Array{Float64,2})
   return vec(sum(A, 2))
 end
 
-@doc """ Expected number of ingoing degrees
-""" ->
+""" Expected number of ingoing degrees
+"""
 function degree_in(A::Array{Float64,2})
   return vec(sum(A, 1))
 end
 
-@doc """ Expected degree
-""" ->
+""" Expected degree
+"""
 function degree(A::Array{Float64,2})
   @assert size(A)[1] == size(A)[2]
   return degree_in(A) .+ degree_out(A)

--- a/src/free_species.jl
+++ b/src/free_species.jl
@@ -1,34 +1,34 @@
-@doc """ Probability that a species has no predecessors """ ->
+""" Probability that a species has no predecessors """
 function species_has_no_predecessors(A::Array{Float64,2})
   @assert size(A)[1] == size(A)[2]
   return vec(prod(1.0 .- nodiag(A),1))
 end
 
-@doc """ Probability that a species has no successors """ ->
+""" Probability that a species has no successors """
 function species_has_no_successors(A::Array{Float64,2})
   @assert size(A)[1] == size(A)[2]
   return vec(prod(1.0 .- nodiag(A),2))
 end
 
-@doc """ Probability that a species has no links
+""" Probability that a species has no links
 
 This will return a vector, where the *i*th element is the probability that
 species *i* has no interaction. Note that this is only meaningful for unipartite
 networks.
 
-""" ->
+"""
 function species_is_free(A::Array{Float64,2})
   @assert size(A)[1] == size(A)[2]
   return species_has_no_successors(A) .* species_has_no_predecessors(A)
 end
 
-@doc """ Expected number of species with no interactions
+""" Expected number of species with no interactions
 
 This function will be applied on the *unipartite* version of the network. Note
 that the functions `species_ |predecessors` will work on bipartite networks, but
 the unipartite situation is more general.
 
-""" ->
+"""
 function free_species(A::Array{Float64,2})
   if length(unique(size(A))) == 1
     return A |> species_is_free |> sum

--- a/src/matrix_utils.jl
+++ b/src/matrix_utils.jl
@@ -1,7 +1,7 @@
-@doc """Transforms a bipartite network into a unipartite network
+"""Transforms a bipartite network into a unipartite network
 
 Note that this function returns an asymetric unipartite network.
-""" ->
+"""
 function make_unipartite(A::Array{Float64,2})
   S = sum(size(A))
   B = zeros(Float64,(S,S))
@@ -12,11 +12,11 @@ end
 #=
 Generates a random binary matrix based on a probabilistic one
 =#
-@doc """Generate a random 0/1 matrix from probabilities
+"""Generate a random 0/1 matrix from probabilities
 
 Returns a matrix B of the same size as A, in which each element B(i,j) is 1 with
 probability A(i,j).
-""" ->
+"""
 function make_bernoulli(A::Array{Float64,2})
   return float64(rand(size(A)) .<= A)
   # This next line will work once 0.4 becomes the current release. For now, the
@@ -28,11 +28,11 @@ end
 #=
 Sets the diagonal to 0
 =#
-@doc """Sets the diagonal to 0
+"""Sets the diagonal to 0
 
 Returns a copy of the matrix A, with  the diagonal set to 0. Will fail if the
 matrix is not square.
-""" ->
+"""
 function nodiag(A::Array{Float64,2})
   # The diagonal is only relevant for square matrices
   @assert size(A)[1] == size(A)[2]
@@ -42,7 +42,7 @@ end
 #=
 Use a threshold
 =#
-@doc """Generate a random 0/1 matrix from probabilities
+"""Generate a random 0/1 matrix from probabilities
 
 Returns a matrix B of the same size as A, in which each element B(i,j) is 1 if
 A(i,j) is > `k`. This is probably unwise to use this function since this
@@ -50,7 +50,7 @@ practice is of questionnable relevance, but it is included for the sake of
 exhaustivity.
 
 `k` must be in [0;1[.
-""" ->
+"""
 function make_threshold(A::Array{Float64,2}, k::Float64)
   # Check the values of k
   if (k < 0.0) | (k >= 1.0)
@@ -63,11 +63,11 @@ end
 #=
 Set all probabilities to 1.0
 =#
-@doc """Returns the adjacency/incidence matrix from a probability matrix
+"""Returns the adjacency/incidence matrix from a probability matrix
 
 Returns a matrix B of the same size as A, in which each element B(i,j) is 1 if
 A(i,j) is greater than 0.
-""" ->
+"""
 function make_binary(A::Array{Float64,2})
   return make_threshold(A, 0.0)
 end

--- a/src/modularity.jl
+++ b/src/modularity.jl
@@ -1,7 +1,7 @@
 #=
 Partition, a type to store a community partition
 =#
-@doc """
+"""
 Type to store a community partition
 
 This type has three elements:
@@ -10,7 +10,7 @@ This type has three elements:
 - `L`, the array of (integers) module labels
 - `Q`, if needed, the modularity value
 
-""" ->
+"""
 type Partition
     A::Array{Float64, 2}
     L::Array{Int64, 1}
@@ -20,12 +20,12 @@ end
 #=
 Modularity function
 =#
-@doc """
+"""
 Q -- a measure of modularity
 
 This measures Barber's bipartite modularity based on a matrix and a list of
 module labels.
-""" ->
+"""
 function Q(A::Array{Float64, 2}, L::Array{Int64, 1})
   if length(unique(L)) == 1
     return 0.0
@@ -38,12 +38,12 @@ function Q(A::Array{Float64, 2}, L::Array{Int64, 1})
   return sum((aij .- kij) .* (L .== L'))
 end
 
-@doc """
+"""
 Q -- a measure of modularity
 
 This measures Barber's bipartite modularity based on a `Partition` object, and
 update the object in the proccess.
-""" ->
+"""
 function Q(P::Partition)
   P.Q = Q(P.A, P.L)
   P.Q
@@ -52,7 +52,7 @@ end
 #=
 Realized modularity function
 =#
-@doc """
+"""
 Qr -- a measure of realized modularity
 
 Measures Poisot's realized modularity, based on a  a matrix and a list of module
@@ -61,7 +61,7 @@ proportion of interactions established *within* modules.
 
 Note that in some situations, `Qr` can be *lower* than 0. This reflects a
 partition in which more links are established between than within modules.
-""" ->
+"""
 function Qr(A::Array{Float64, 2}, L::Array{Int64, 1})
   if length(unique(L)) == 1
     return 0.0
@@ -72,11 +72,11 @@ function Qr(A::Array{Float64, 2}, L::Array{Int64, 1})
 end
 
 
-@doc """
+"""
 Qr -- a measure of realized modularity
 
 Measures Poisot's realized modularity, based on a `Partition` object.
-""" ->
+"""
 function Qr(P::Partition)
   return Qr(P.A, P.L)
 end
@@ -84,7 +84,7 @@ end
 #=
 Propagate labels edge by edge
 =#
-@doc """
+"""
 A **very** experimental label propagation method for probabilistic networks
 
 This function is a take on the usual LP method for community detection. Instead
@@ -95,7 +95,7 @@ for non-probabilistic networks.
 
 The other pitfall is that there is a need to do a *large* number of iterations
 to get to a good partition. This method is also untested.
-""" ->
+"""
 function propagate_labels(A::Array{Float64, 2}, kmax::Int64, smax::Int64)
   # Make a list of labels
   n_lab = maximum(size(A))

--- a/src/motifs.jl
+++ b/src/motifs.jl
@@ -1,11 +1,11 @@
-@doc """ Internal motif calculations
+""" Internal motif calculations
 
 The two arguments are `A` the adjacency matrix (probabilistic) and `m` the motif
 adjacency matrix (0.0 or 1.0 only). The two matrices must have the same size.
 The function returns a *vectorized* probability of each interaction being in the
 right state for the motif, *i.e.* P if m is 1, and 1 - P if m is 0.
 
-""" ->
+"""
 function motif_internal(A::Array{Float64, 2}, m::Array{Float64, 2})
   # The motif structure can only be 0 or 1
   @assert sort(unique(m)) == vec([0.0 1.0]) || unique(m) == vec([0.0]) || unique(m) == vec([1.0])
@@ -18,23 +18,23 @@ function motif_internal(A::Array{Float64, 2}, m::Array{Float64, 2})
   return vec(b .- A)
 end
 
-@doc """ Probability that a group of species form a given motif """ ->
+""" Probability that a group of species form a given motif """
 function motif_p(A::Array{Float64, 2}, m::Array{Float64, 2})
   return prod(motif_internal(A, m))
 end
 
-@doc """ Variance that a group of species form a given motif """ ->
+""" Variance that a group of species form a given motif """
 function motif_v(A::Array{Float64, 2}, m::Array{Float64, 2})
   return m_var(motif_internal(A, m))
 end
 
-@doc """ Motif counter
+""" Motif counter
 
 This function will go through all k-permutations of `A` to measure the
 probability of each induced subgraph being an instance of the motif given by
 `m` (the square adjacency matrix of the motif, with 0 and 1).
 
-""" ->
+"""
 function count_motifs(A::Array{Float64, 2}, m::Array{Float64, 2})
    # Both should be square matrices -- this makes my life easier
    @assert size(A)[1] == size(A)[2]
@@ -56,12 +56,12 @@ function count_motifs(A::Array{Float64, 2}, m::Array{Float64, 2})
    return single_probas
 end
 
-@doc """ Expected number of a given motif """ ->
+""" Expected number of a given motif """
 function motif(A::Array{Float64, 2}, m::Array{Float64, 2})
   return sum(float(count_motifs(A, m)))
 end
 
-@doc """ Expected variance of a given motif """ ->
+""" Expected variance of a given motif """
 function motif_var(A::Array{Float64, 2}, m::Array{Float64, 2})
   return a_var(float(count_motifs(A, m)))
 end

--- a/src/nestedness.jl
+++ b/src/nestedness.jl
@@ -1,5 +1,5 @@
-@doc """Nestedness of a single axis (called internally by `nestedness`)
-""" ->
+"""Nestedness of a single axis (called internally by `nestedness`)
+"""
 function nestedness_axis(A::Array{Float64,2}; axis::Int64=1)
     @assert axis in 1:2
     if axis == 2
@@ -20,14 +20,14 @@ function nestedness_axis(A::Array{Float64,2}; axis::Int64=1)
     return sum(num ./ den)
 end
 
-@doc """Nestedness of a matrix, using the Bastolla et al. (XXXX) measure
+"""Nestedness of a matrix, using the Bastolla et al. (XXXX) measure
 
 Returns three values:
 
 - nestedness of the entire matrix
 - nestedness of the columns
 - nestedness of the rows
-""" ->
+"""
 function nestedness(A::Array{Float64,2})
    n_1 = nestedness_axis(A, axis=1)
    n_2 = nestedness_axis(A, axis=2)

--- a/src/nullmodels.jl
+++ b/src/nullmodels.jl
@@ -1,10 +1,10 @@
 #=
 Type I
 =#
-@doc """
+"""
 Given a matrix `A`, `null1(A)` returns a matrix with the same dimensions, where
 every interaction happens with a probability equal to the connectance of `A`.
-""" ->
+"""
 function null1(A::Array{Float64, 2})
   return ones(A) .* connectance(A)
 end
@@ -12,12 +12,12 @@ end
 #=
 Type III out
 =#
-@doc """
+"""
 Given a matrix `A`, `null3out(A)` returns a matrix with the same dimensions,
 where every interaction happens with a probability equal to the out-degree
 (number of successors) of each species, divided by the total number of possible
 successors.
-""" ->
+"""
 function null3out(A::Array{Float64, 2})
   p_rows = degree_out(A) ./ size(A)[2]
   return hcat(map((x) -> p_rows, [1:size(A)[2];])...)
@@ -26,12 +26,12 @@ end
 #=
 Type III in
 =#
-@doc """
+"""
 Given a matrix `A`, `null3in(A)` returns a matrix with the same dimensions,
 where every interaction happens with a probability equal to the in-degree
 (number of predecessors) of each species, divided by the total number of
 possible predecessors.
-""" ->
+"""
 function null3in(A::Array{Float64, 2})
   return null3out(A')' # I don't work hard, so I work smart
 end
@@ -39,11 +39,11 @@ end
 #=
 Type II
 =#
-@doc """
+"""
 Given a matrix `A`, `null2(A)` returns a matrix with the same dimensions, where
 every interaction happens with a probability equal to the degree of each
 species.
-""" ->
+"""
 function null2(A::Array{Float64, 2})
   return (null3in(A) .+ null3out(A))./2.0
 end
@@ -58,7 +58,7 @@ This function will try to run in parallel, because otherwise it takes forever to
 go through all of the potential networks.
 
 =#
-@doc """ This function is a wrapper to generate replicated binary matrices from
+""" This function is a wrapper to generate replicated binary matrices from
 a template probability matrix `A`.
 
 If you use julia on more than one CPU, *i.e.* if you started it with `julia -p
@@ -75,7 +75,7 @@ routines will be part of a later release.
 - `n` (def. 1000), number of replicates to generate
 - `max` (def. 10000), number of trials to make
 
-""" ->
+"""
 function nullmodel(A::Array{Float64, 2}; n=1000, max=10000)
   if max < n
     max = n

--- a/src/paths.jl
+++ b/src/paths.jl
@@ -1,9 +1,9 @@
-@doc """ Measures the expected number of paths in a probabilistic network
+""" Measures the expected number of paths in a probabilistic network
 
 **Keyword arguments**
 
 - `n` (def. 2), the path length
-""" ->
+"""
 function number_of_paths(A::Array{Float64,2}; n::Int64=2)
   @assert size(A)[1] == size(A)[2]
   @assert n >= 2

--- a/src/proba_utils.jl
+++ b/src/proba_utils.jl
@@ -5,14 +5,14 @@ and at most 1
 It is called internally by the i_var and i_esp function to make sure that
 the arguments are actually probabilities
 =#
-@doc """Quite crude way of checking that a number is a probability
+"""Quite crude way of checking that a number is a probability
 
 The two steps are
 
 1. The number should be of the `Float64` type -- if not, will yield a `TypeError`
 2. The number should belong to [0,1] -- if not, will throw a `DomainError`
 
-""" ->
+"""
 macro checkprob(p)
 	quote
 		# Check the correct type
@@ -31,10 +31,10 @@ end
 #=
 Esperance of a Bernoulli process (p)
 =#
-@doc """Expected value of a single Bernoulli event
+"""Expected value of a single Bernoulli event
 
 Simply f(p): p
-""" ->
+"""
 function i_esp(p::Float64)
 	@checkprob p
 	return p
@@ -44,10 +44,10 @@ end
 #=
 Variance of a Bernoulli process (p(1-p))
 =#
-@doc """Variance of a single Bernoulli event
+"""Variance of a single Bernoulli event
 
 f(p): p(1-p)
-""" ->
+"""
 function i_var(p::Float64)
   @checkprob p
   return p*(1.0-p)
@@ -57,10 +57,10 @@ end
 #=
 Variance of additive events
 =#
-@doc """Variance of a series of additive Bernoulli events
+"""Variance of a series of additive Bernoulli events
 
 f(p): ∑(p(1-p))
-""" ->
+"""
 function a_var(p::Array{Float64})
 	return reduce(+, map(i_var, p))
 end
@@ -68,8 +68,8 @@ end
 #=
 Variance of multiplicative events
 =#
-@doc """Variance of a series of multiplicative Bernoulli events
-""" ->
+"""Variance of a series of multiplicative Bernoulli events
+"""
 function m_var(p::Array{Float64})
 	return reduce(*, map((x) -> i_var(x) + i_esp(x)*i_esp(x), p)) - reduce(*, map((x) -> i_esp(x)*i_esp(x), p))
 end


### PR DESCRIPTION
Fixes #33.

- Removes all ``@doc`` usages and direct import of ``Docile``.
- Conditionally import Lexicon in Julia 0.3 so that docstrings are available from ``?`` mode immediately after loading the package.
- Remove direct ``REQUIRE`` entry for Docile since ``Lexicon`` already pulls in that dependency.