### PR TITLE
Feature path algorithms

### DIFF
--- a/docs/src/properties/paths.md
+++ b/docs/src/properties/paths.md
@@ -5,6 +5,7 @@
 ```@docs
 number_of_paths
 shortest_path
+bellman_ford
 ```
 
 ## Centrality measures

--- a/src/EcologicalNetwork.jl
+++ b/src/EcologicalNetwork.jl
@@ -64,7 +64,7 @@ export η, nodf
 
 # Paths
 include(joinpath(".", "community/paths.jl"))
-export number_of_paths, shortest_path
+export number_of_paths, shortest_path, bellman_ford
 
 # Centrality
 include(joinpath(".", "community/centrality.jl"))

--- a/src/community/paths.jl
+++ b/src/community/paths.jl
@@ -1,6 +1,4 @@
 """
-**Number of paths of length n between all pairs of nodes**
-
     number_of_paths(N::Unipartite; n::Int64=2)
 
 This returns an array, not a network.
@@ -17,8 +15,6 @@ function number_of_paths(N::UnipartiteQuantitativeNetwork; n::Int64=2)
 end
 
 """
-**Shortest paths**
-
     shortest_path(N::UnipartiteNetwork; nmax::Int64=50)
 
 This is not an optimal algorithm *at all*, but it will do given that most
@@ -27,7 +23,7 @@ longest shortest path length you will look for.
 
 In ecological networks, the longest shortest path tends not to be very long, so
 any value above 10 is probably overdoing it. Note that the default value is 50,
-which is above 10. But why just do, when you can overdo?
+which is above 10.
 """
 function shortest_path(N::UnipartiteNetwork; nmax::Int64=50)
   # We will have a matrix of the same size at the adjacency matrix
@@ -91,6 +87,12 @@ of species in the networks, as long as paths exists. This function will return a
 tuple, with fields `from`, `to` and `weight`. The number of elements in the
 tuple is the number of paths. This function works with quantitative and binary
 networks, and assumes that no interactions are negative.
+
+Currently, the Bellman-Ford algorithm is *slower* than the `shortest_path`
+function, but the arguments are returned in a more usable way. Note that the
+speed penalty is only valid when measuring the shortest paths in the entire
+network (and will be fixed relatively soon), and does not apply as much for the
+shortest paths from a single source node. 
 """
 function bellman_ford(N::T) where {T <: DeterministicNetwork}
     global paths

--- a/src/types/conversions.jl
+++ b/src/types/conversions.jl
@@ -6,7 +6,7 @@ import Base.convert
 Projects a deterministic bipartite network in its unipartite representation.
 """
 function convert(::Type{UnipartiteNetwork}, N::T) where {T <: BipartiteNetwork}
-    itype = last(eltype(N))
+    itype = first(eltype(N))
     S = copy(species(N))
     B = zeros(itype, (richness(N), richness(N)))
     B[1:size(N)[1],size(N)[1]+1:richness(N)] = N.A

--- a/src/types/conversions.jl
+++ b/src/types/conversions.jl
@@ -6,7 +6,7 @@ import Base.convert
 Projects a deterministic bipartite network in its unipartite representation.
 """
 function convert(::Type{UnipartiteNetwork}, N::T) where {T <: BipartiteNetwork}
-    itype = first(eltype(N))
+    itype = last(eltype(N))
     S = copy(species(N))
     B = zeros(itype, (richness(N), richness(N)))
     B[1:size(N)[1],size(N)[1]+1:richness(N)] = N.A

--- a/test.jl
+++ b/test.jl
@@ -5,8 +5,7 @@ using StatsBase
 using NamedTuples
 using StatPlots
 
-N = web_of_life("A_HP_002")
-Traceur.@trace connectance(N)
-Traceur.@trace degree(N, 1)
+N = nz_stream_foodweb()[5]
 
-Traceur.@trace each_species_its_module(N)
+
+bellman_ford(N)

--- a/test/community/paths.jl
+++ b/test/community/paths.jl
@@ -17,4 +17,9 @@ module TestPaths
   @test number_of_paths(U) == number_of_paths(UnipartiteNetwork(m.>0))
   @test shortest_path(U) == shortest_path(UnipartiteNetwork(m.>0))
 
+  N = unipartitemotifs()[:S1]
+  b = bellman_ford(N)
+  @test length(b) == 3
+  @test length(filter(x -> x.to == :c, b)) == 2
+
 end


### PR DESCRIPTION
# Add Bellman-Ford shortest path algorithm

Add two `bellman_ford` methods, one for the network, one for a single source, to get the weights of shortest paths in deterministic networks.

## Related issues

#104 

## Checklist

- [x] The code is covered by unit tests
  - [x] Additional cases or module in `test/...`
  - [x] Relevant lines in `test/runtests.jl`
- [x] The code is *documented*
  - [x] Docstrings written for every function
  - [x] If needed, additional lines in `docs/src/...`